### PR TITLE
Rh/dev

### DIFF
--- a/apps/diegesis-admin-client/src/components/TabsTabs.js
+++ b/apps/diegesis-admin-client/src/components/TabsTabs.js
@@ -9,5 +9,6 @@ export default function TabsTabs({selectedTabIndex, setSelectedTabIndex, selecte
 
     return <Tabs size="small" value={selectedTabIndex} onChange={handleChange} aria-label="local/remote tabs">
         <Tab label="Local" id="simple-tab-0" aria-controls="simple-tabpanel-0"/>
+        <Tab label="Remote" id="simple-tab-1" aria-controls="simple-tabpanel-1"/>
     </Tabs>
 }

--- a/apps/diegesis-user-client/src/App.js
+++ b/apps/diegesis-user-client/src/App.js
@@ -14,6 +14,7 @@ import ListPage from "./pages/ListPage";
 import BlendPage from "./pages/BlendPage";
 import EntryDetailsPage from "./pages/EntryDetailsPage";
 import EntryBrowsePage from "./pages/EntryBrowsePage";
+import EntrySearchPage from "./pages/EntrySearchPage";
 import EntryDownloadPage from "./pages/EntryDownloadPage";
 import { AppLangProvider } from "./contexts/AppLangContext";
 
@@ -70,6 +71,11 @@ function App() {
         {
             path: "/entry/browse/:source/:entryId/:revision",
             element: <EntryBrowsePage setAppLanguage={setAppLanguage}/>,
+            errorElement: <ErrorBoundary/>
+        },
+        {
+            path: "/entry/search/:source/:entryId/:revision",
+            element: <EntrySearchPage setAppLanguage={setAppLanguage}/>,
             errorElement: <ErrorBoundary/>
         },
         {

--- a/apps/diegesis-user-client/src/components/BrowseScripture.js
+++ b/apps/diegesis-user-client/src/components/BrowseScripture.js
@@ -1,11 +1,16 @@
-import React, {useState, useEffect} from 'react';
+import React, {useContext, useState, useEffect} from 'react';
+import {Link as RouterLink} from 'react-router-dom';
 import {Typography, Grid, Switch, FormGroup, FormControlLabel, Box, Button} from "@mui/material";
 import {Tune} from '@mui/icons-material';
 import {SofriaRenderFromProskomma} from "proskomma-json-tools";
 import sofria2WebActions from '../renderer/sofria2web';
 import DocSelector from "./DocSelector";
+import AppLangContext from "../contexts/AppLangContext";
+import i18n from "../i18n";
 
-export default function BrowseScripture({pk}) {
+export default function BrowseScripture({pk, ri}) {
+    const appLang = useContext(AppLangContext);
+    const searchTitle = i18n(appLang, "CONTROLS_SEARCH");
 
     const [scriptureData, setScriptureData] = useState({
         docId: null,
@@ -156,7 +161,7 @@ export default function BrowseScripture({pk}) {
 
     return (
         <Grid container>
-            <Grid item xs={12} sm={6} md={4} lg={2}>
+            <Grid item xs={12} sm={4} md={2} lg={2}>
                 <Box sx={{marginRight: "5px"}}>
                     <FormGroup sx={{padding: "10px", backgroundColor: showSettings ? "#ccc" : "inherit"}}>
                         <Button
@@ -282,13 +287,22 @@ export default function BrowseScripture({pk}) {
                     </FormGroup>
                 </Box>
             </Grid>
-            <Grid item xs={12} sm={6} md={8} lg={10}>
+            <Grid item xs={12} sm={4} md={7} lg={8}>
                 <DocSelector
                     docs={docMenuItems}
                     docId={scriptureData.docId}
                     setDocId={setDocId}
                     disabled={!scriptureData.rendered || scriptureData.docId !== scriptureData.renderedDocId || scriptureData.updatedAtts}
                 />
+            </Grid>
+            <Grid item xs={12} sm={4} md={3} lg={2} sx={{ justifySelf: "flex-end" }}>
+                <Button>
+                    <RouterLink
+                        to={`/entry/search/${ri.source}/${ri.entryId}/${ri.revision}`}
+                        style={{textDecoration: "none"}}>
+                        <Typography variant="body1">{searchTitle}</Typography>
+                    </RouterLink>
+                </Button>
             </Grid>
             <Grid item xs={12}>
                 {

--- a/apps/diegesis-user-client/src/components/SearchScripture.js
+++ b/apps/diegesis-user-client/src/components/SearchScripture.js
@@ -2,48 +2,83 @@ import React, {useContext, useState, useEffect} from 'react';
 import {Typography, TextField, Grid} from "@mui/material";
 import AppLangContext from "../contexts/AppLangContext";
 import i18n from "../i18n";
+import DocSelector from "./DocSelector";
 
 export default function SearchScripture({pk}) {
 
     const appLang = useContext(AppLangContext);
     const searchTitle = i18n(appLang, "CONTROLS_SEARCH");
 
+    const [docId, setDocId] = useState("");
+    const [docMenuItems, setDocMenuItems] = useState([]);
     const [searchQuery, setSearchQuery] = useState("");
-
+    const [validQuery, setValidQuery] = useState(false);
     const [matches, setMatches] = useState([]);
+
+    const docName = d => {
+      return d.headers.filter(d => d.key === 'toc3')[0]?.value ||
+          d.headers.filter(d => d.key === 'h')[0]?.value ||
+          d.headers.filter(d => d.key === 'toc2')[0]?.value ||
+          d.headers.filter(d => d.key === 'toc')[0]?.value ||
+          d.headers.filter(d => d.key === 'bookCode')[0].value
+    }
+
+    useEffect(() => {
+      const docSetInfo = pk.gqlQuerySync(
+        `{
+          docSets {
+            documents(sortedBy:"paratext") {
+              id
+              headers { key value }
+            }
+          }
+        }`
+      );
+      
+      setDocId(docSetInfo.data.docSets[0].documents[0].id);
+      setDocMenuItems(docSetInfo.data.docSets[0].documents.map(d => ({id: d.id, label: docName(d)})));
+
+    }, []) // this function (likely) only needs to run on initialization. Is this a good way of making such a function?
     
     useEffect(() => {
-      const re = /^[HhGg]\d{3,4}$/;
+      const re = /^[hHgG]\d{3,4}$/; // Strong's number pattern
 
       if(!re.test(searchQuery))
       {
-        console.log("no match");
+        setValidQuery(false);
         return;
       }
 
-      const uCSearchQuery = searchQuery.toUpperCase;
-
+      setValidQuery(true);
       const strongAtts = "attribute/spanWithAtts/w/strong/0/";
-
       const query = 
         `{
-          documents(sortedBy:"paratext") {
-            cvMatching( withScopes:["${strongAtts}${uCSearchQuery}"]) {
+          document(id: "${docId}" ) {
+            cvMatching( withScopes:["${strongAtts}${searchQuery.toUpperCase()}"]) {
               scopeLabels text
             }
           }
         }`;
 
-        // Syntax like this should work when searching for multiple inputs
+        // Syntax like this should work when querying for multiple strong's numbers
         // cvMatching( withScopes:["${strongAtts}${searchQuery[0]}", "${strongAtts}${searchQuery[1]}"]) {
 
         const result = pk.gqlQuerySync(query);
 
-        console.log(result);
+        setMatches(result.data.document.cvMatching.map(d => (
+          {c: d.scopeLabels[1].replace(/\D/g,''), v: d.scopeLabels[2].replace(/\D/g,''), t: d.text}
+          )));
     }, [searchQuery]);
 
     return (
         <Grid container>
+            <Grid item xs={12} sm={4} md={7} lg={8}>
+              <DocSelector
+                  docs={docMenuItems}
+                  docId={docId}
+                  setDocId={setDocId}
+              />
+            </Grid>
             <Grid item xs={12} sm={4} md={3} lg={2}>
               <TextField
                 value={searchQuery}
@@ -58,8 +93,9 @@ export default function SearchScripture({pk}) {
             </Grid>
             <Grid item xs={12}>
                 {
+                  !validQuery ? <Typography>Enter valid Strong's number in search box...</Typography> :
                   matches.length === 0 ?
-                  <Typography>No results...</Typography> :
+                  <Typography>There are no occurrences of this Strong's number in the selected book...</Typography> :
                   <Typography>Results found, but we'll have to work on how to display them...</Typography>
                 }
             </Grid>

--- a/apps/diegesis-user-client/src/components/SearchScripture.js
+++ b/apps/diegesis-user-client/src/components/SearchScripture.js
@@ -46,6 +46,13 @@ export default function SearchScripture({pk}) {
       if(!re.test(searchQuery))
       {
         setValidQuery(false);
+        setMatches([]);
+        return;
+      }
+
+      if(!docId)
+      {
+        setMatches([]);
         return;
       }
 
@@ -66,20 +73,27 @@ export default function SearchScripture({pk}) {
         const result = pk.gqlQuerySync(query);
 
         setMatches(result.data.document.cvMatching.map(d => (
-          {c: d.scopeLabels[1].replace(/\D/g,''), v: d.scopeLabels[2].replace(/\D/g,''), t: d.text}
+          {c: findValueForLabel(d.scopeLabels, /chapter/), v: findValueForLabel(d.scopeLabels, /verse/), t: d.text}
           )));
-    }, [searchQuery]);
+    }, [searchQuery, docId]);
+
+    // This could be some kind of utility function
+    const findValueForLabel = (scopeLabels, label) => {      
+      for (var i=0; i<scopeLabels.length; i++) {
+        if (label.test(scopeLabels[i])) return scopeLabels[i].replace(/\D/g,'');
+      }
+    }
 
     return (
         <Grid container>
-            <Grid item xs={12} sm={4} md={7} lg={8}>
+            <Grid item xs={12} sm={6} md={4} lg={2}>
               <DocSelector
                   docs={docMenuItems}
                   docId={docId}
                   setDocId={setDocId}
               />
             </Grid>
-            <Grid item xs={12} sm={4} md={3} lg={2}>
+            <Grid item xs={12} sm={6} md={4} lg={2}>
               <TextField
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
@@ -96,7 +110,16 @@ export default function SearchScripture({pk}) {
                   !validQuery ? <Typography>Enter valid Strong's number in search box...</Typography> :
                   matches.length === 0 ?
                   <Typography>There are no occurrences of this Strong's number in the selected book...</Typography> :
-                  <Typography>Results found, but we'll have to work on how to display them...</Typography>
+                  <div>
+                    <p>{matches.length} occurrences found:</p>
+                    <ul>
+                    {matches.map(match => {
+                      return <li>{docMenuItems.find((doc) => doc.id === docId).label + " " + match.c + ":" + match.v}<br />
+                        {match.t}
+                      </li>;
+                    })}
+                  </ul>
+                  </div>                  
                 }
             </Grid>
         </Grid>

--- a/apps/diegesis-user-client/src/components/SearchScripture.js
+++ b/apps/diegesis-user-client/src/components/SearchScripture.js
@@ -1,0 +1,100 @@
+import React, {useContext, useState, useEffect} from 'react';
+import {Typography, TextField, Grid, Switch, FormGroup, FormControlLabel, Box, Button} from "@mui/material";
+import {Tune} from '@mui/icons-material';
+import {SofriaRenderFromProskomma} from "proskomma-json-tools";
+import sofria2WebActions from '../renderer/sofria2web';
+import DocSelector from "./DocSelector";
+import AppLangContext from "../contexts/AppLangContext";
+import i18n from "../i18n";
+
+export default function SearchScripture({pk}) {
+
+    const appLang = useContext(AppLangContext);
+    const searchTitle = i18n(appLang, "CONTROLS_SEARCH");
+
+    const [searchQuery, setSearchQuery] = useState("");
+
+
+    useEffect(() => {
+      const docIdsStruct = pk.gqlQuerySync(
+        `{
+          docSets {
+            documents(sortedBy:"paratext") {
+              id
+              headers { key value }
+            }
+          }
+        }`);
+      const docId = docIdsStruct.data.docSets[0].documents[0].id; // Just grab Genesis for now
+
+      const seqIdsStruct = pk.gqlQuerySync(
+        `{
+          document(id: "${docId}" ) {
+            sequences {
+              id
+            }
+          }
+        }`);
+      const seqIds = seqIdsStruct.data.document.sequences;
+      const payloads = seqIds.map((seqId) => ( getPayloadsForSequence(docId, seqId.id)));
+      console.log(payloads);
+      // Search the payloads, and match for searchQuery
+
+
+    }, [searchQuery]);
+
+    const getPayloadsForSequence = (docId, seqId) => {    
+        const payloads = [];
+        const numBlocksStruct = pk.gqlQuerySync(
+          `{
+            document(id: "${docId}" ) {
+              sequence(id: "${seqId}") {
+                nBlocks
+              }                 
+            }   
+          }`);
+        const numBlocks = numBlocksStruct.data.document.sequence.nBlocks;
+        for (let block = 0; block < numBlocks; block++) {
+            const payloadStruct = pk.gqlQuerySync(
+              `{
+                document(id: "${docId}" ) {
+                  sequence(id: "${seqId}") {
+                    blocks(positions: ${block}) {
+                      items {
+                        payload
+                      }
+                    }
+                  }                 
+                }   
+              }`);
+            payloads.push(payloadStruct.data.document.sequence.blocks[0].items);
+        }
+        return payloads;
+    }           
+
+    const matches = [];
+
+    return (
+        <Grid container>
+            <Grid item xs={12} sm={4} md={3} lg={2}>
+              <TextField
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                label={searchTitle}
+                size="small"
+                id="searchOwner"
+                variant="filled"
+                color="primary"
+                sx={{ display: "flex", marginLeft: "1em" }}
+              />
+            </Grid>
+            <Grid item xs={12}>
+                {
+                  matches.length === 0 ?
+                  <Typography>No results...</Typography> :
+                  <Typography>Results found, but we'll have to work on how to display them...</Typography>
+                }
+            </Grid>
+        </Grid>
+    )
+}

--- a/apps/diegesis-user-client/src/components/SearchScripture.js
+++ b/apps/diegesis-user-client/src/components/SearchScripture.js
@@ -77,8 +77,6 @@ export default function SearchScripture({pk}) {
 
         const result = pk.gqlQuerySync(query);
 
-        console.log(result);
-
         setMatches(result.data.document.cvMatching.map(d => (
           {c: findValueForLabel(d.scopeLabels, /chapter/), v: findValueForLabel(d.scopeLabels, /verse/), t: d.tokens}
           )));
@@ -114,9 +112,9 @@ export default function SearchScripture({pk}) {
             </Grid>
             <Grid item xs={12}>
                 {
-                  !validQuery ? <Typography>Enter valid Strong's number in search box...</Typography> :
+                  !validQuery ? <p>Enter valid Strong's number in search box...</p> :
                   matches.length === 0 ?
-                  <Typography>There are no occurrences of this Strong's number in the selected book...</Typography> :
+                  <p>There are no occurrences of this Strong's number in the selected book...</p> :
                   <div>
                     <p>{matches.length} occurrences found:</p>
                     <ul>

--- a/apps/diegesis-user-client/src/components/SearchScripture.js
+++ b/apps/diegesis-user-client/src/components/SearchScripture.js
@@ -93,7 +93,7 @@ export default function SearchScripture({pk}) {
 
     return (
         <Grid container>
-            <Grid item xs={12} sm={6} md={4} lg={2}>
+            <Grid item xs={12} sm={6} md={8} lg={10}>
               <DocSelector
                   docs={docMenuItems}
                   docId={docId}
@@ -122,11 +122,10 @@ export default function SearchScripture({pk}) {
                     <ul>
                     {matches.map(match => {
                       return <li>{docMenuItems.find((doc) => doc.id === docId).label + " " + match.c + ":" + match.v}<br />
-                        <p>{match.t.map(token => {
+                        {match.t.map(token => {
                           return token.scopes.length === 1 ? token.scopes[0].includes(searchQuery.toUpperCase()) ?
-                            <b>{token.payload}</b> : token.payload : 
-                            token.payload
-                        })}</p>
+                            <b>{token.payload}</b> : token.payload : token.payload
+                        })}
                       </li>;
                     })}
                   </ul>

--- a/apps/diegesis-user-client/src/i18n/languageTexts/en.json
+++ b/apps/diegesis-user-client/src/i18n/languageTexts/en.json
@@ -64,6 +64,7 @@
     "CONTROLS_OT":"OT",
     "CONTROLS_NT":"NT",
     "CONTROLS_DC":"DC",
+    "CONTROLS_SEARCH": "Search",
     "RESOURCE_TYPES":"Resource Types",
     "en_LANG":"English",
     "ar_LANG":"Arabic",

--- a/apps/diegesis-user-client/src/pages/EntrySearchPage.js
+++ b/apps/diegesis-user-client/src/pages/EntrySearchPage.js
@@ -9,12 +9,12 @@ import GqlError from "../components/GqlError";
 import Header from "../components/Header";
 import Footer from "../components/Footer";
 import Spinner from "../components/Spinner";
-import BrowseScripture from "../components/BrowseScripture";
+import SearchScripture from "../components/SearchScripture";
 import {directionText} from "../i18n/languageDirection";
 import AppLangContext from "../contexts/AppLangContext";
 // const ProskommaRequire = require('proskomma-core');
 
-export default function EntryBrowsePage({setAppLanguage}) {
+export default function EntrySearchPage({setAppLanguage}) {
     const appLang = useContext(AppLangContext);
     const {source, entryId, revision} = useParams();
 
@@ -94,7 +94,7 @@ export default function EntryBrowsePage({setAppLanguage}) {
         <Box style={{marginTop: "100px"}}>
             <Typography variant="h4" paragraph="true" sx={{mt: "20px"}}>
                 <Button>
-                    <RouterLink to={`/entry/details/${source}/${entryId}/${revision}`}><ArrowBack/></RouterLink>
+                    <RouterLink to={`/entry/browse/${source}/${entryId}/${revision}`}><ArrowBack/></RouterLink>
                 </Button>
                 {entryInfo && entryInfo.title}
                 {!entryInfo && "Loading..."}
@@ -102,7 +102,7 @@ export default function EntryBrowsePage({setAppLanguage}) {
             {
                 entryInfo &&
                 entryInfo.canonResource &&
-                entryInfo.canonResource.content && <BrowseScripture pk={pk} ri={{source: source, entryId: entryId, revision: revision}}/>
+                entryInfo.canonResource.content && <SearchScripture pk={pk}/>
             }
             {
                 (!entryInfo || !entryInfo.canonResource || !entryInfo.canonResource.content) &&


### PR DESCRIPTION
(Please don't delete branch immediately after merge, I'm working on some more things)

Added:
- Button to new Search Scripture page (found on the Browse Scripture page)
- Search Scripture page, which let's you search for occurences of specific Strong's numbers in the selected scripture
  - Input for Strong's number is (for now) limited to the pattern [HhGg]\d{3,4}
  - Search scope can be set to book from dropdown list, or to all books (with the checkbox next to the dropdown list)
- Results are displayed in a list
  - BCV is shown
  - Followed by the related verse, with the match highlighted in **bold**

Known issues:
- When search results are displayed, switching the search scope to '--' (the first entry in the list), a crash occurs

Future work:
- Add support for searching for multiple Strong's numbers in a single query
  - User should be able to indicate if any or if all numbers should be found in a single verse
- Paginate results. At least for the 'All books' searches, since they tend to take about 7 seconds now.